### PR TITLE
ci: deploy to Azure Static Web Apps via GitHub Actions (EXP-1610)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,94 @@
+name: Build and deploy
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    types: [opened, synchronize, reopened, closed]
+    branches:
+      - main
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  build:
+    name: Build
+    if: github.event_name == 'push' || github.event.action != 'closed'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+        env:
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Build site
+        run: npm run build
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: site
+          path: build
+
+  deploy_preview:
+    name: Deploy PR preview
+    needs: build
+    if: github.event_name == 'pull_request' && github.event.action != 'closed'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: site
+          path: build
+
+      - uses: Azure/static-web-apps-deploy@v1
+        with:
+          azure_static_web_apps_api_token: ${{ secrets.AZURE_STATIC_WEB_APPS_API_TOKEN }}
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          action: upload
+          app_location: build
+          output_location: ''
+          skip_app_build: true
+          skip_api_build: true
+
+  deploy_production:
+    name: Deploy production
+    needs: build
+    if: github.event_name == 'push'
+    runs-on: ubuntu-latest
+    environment:
+      name: production
+      url: https://legal.codat.io
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: site
+          path: build
+
+      - uses: Azure/static-web-apps-deploy@v1
+        with:
+          azure_static_web_apps_api_token: ${{ secrets.AZURE_STATIC_WEB_APPS_API_TOKEN }}
+          action: upload
+          app_location: build
+          output_location: ''
+          skip_app_build: true
+          skip_api_build: true
+
+  close_preview:
+    name: Close PR preview
+    if: github.event_name == 'pull_request' && github.event.action == 'closed'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: Azure/static-web-apps-deploy@v1
+        with:
+          azure_static_web_apps_api_token: ${{ secrets.AZURE_STATIC_WEB_APPS_API_TOKEN }}
+          action: close

--- a/static/staticwebapp.config.json
+++ b/static/staticwebapp.config.json
@@ -1,0 +1,8 @@
+{
+  "trailingSlash": "auto",
+  "responseOverrides": {
+    "404": {
+      "rewrite": "/404.html"
+    }
+  }
+}


### PR DESCRIPTION
[EXP-1610](https://codatdocs.atlassian.net/browse/EXP-1610) — migrate legal.codat.io off Vercel to Azure.

## What

- **GitHub Actions workflow** (`.github/workflows/deploy.yml`): build once, then
  - PR → deploy to an Azure Static Web Apps **preview environment** (URL commented on the PR; environment torn down when the PR closes)
  - push to `main` → deploy to **production**, gated behind the `production` GitHub environment (approval required)
- **`static/staticwebapp.config.json`**: serves Docusaurus' `404.html` for not-found routes.

## Decisions (per EXP-1595)

- **SWA for both prod and PR previews** (single toolchain; the epic's leading recommendation)
- **Free SKU** — this site is tiny; easy bump to Standard later if an SLA is ever needed. Free allows 3 concurrent PR preview environments.
- **Single SWA** — PR previews act as the pre-prod check, no separate integration deployment
- **ADO npm feed kept** — CI authenticates with `NPM_TOKEN`, consistent with what help.codat.io will need

## Companion PRs

- codat-internal/infrastructure-as-code#1445 — staticWebApps IaC stack (provisions the SWA)
- codat-internal/infrastructure-as-code#1443 — Vercel decommission (merge last, after cutover)

## Before this can merge

- [ ] SWA provisioned via codat-internal/infrastructure-as-code#1445
- [ ] Repo secret `AZURE_STATIC_WEB_APPS_API_TOKEN` set from the SWA deployment token
- [ ] Repo secret `NPM_TOKEN` set (base64-encoded ADO PAT, same value the Vercel build used)
- [ ] `production` environment created in repo Settings → Environments with required reviewers (this is the approval gate)

DNS cutover and Vercel decommission happen after this merges and prod is verified on the SWA default hostname.

## Verification

- `npm run build` passes locally on Node 22 (matches workflow)
- Build output contains `404.html` and `staticwebapp.config.json` at the root

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[EXP-1610]: https://codatdocs.atlassian.net/browse/EXP-1610?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ