### PR TITLE
ci: deploy to GitHub Pages via GitHub Actions (EXP-1610)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -25,7 +25,7 @@ jobs:
 
       - uses: actions/setup-node@v6
         with:
-          node-version: 22
+          node-version: 24
           cache: npm
 
       - name: Install dependencies

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,53 @@
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          # Full history so showLastUpdateAuthor/Time read real git dates
+          fetch-depth: 0
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+        env:
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Build site
+        run: npm run build
+
+      - uses: actions/configure-pages@v6
+
+      - uses: actions/upload-pages-artifact@v5
+        with:
+          path: build
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@v5

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -11,7 +11,7 @@ jobs:
 
       - uses: actions/setup-node@v6
         with:
-          node-version: 22
+          node-version: 24
           cache: npm
 
       # The ADO registry in .npmrc requires auth even to install, so PR

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,0 +1,25 @@
+name: PR checks
+
+on:
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 22
+          cache: npm
+
+      # The ADO registry in .npmrc requires auth even to install, so PR
+      # builds need NPM_TOKEN too (fork PRs don't get secrets and will fail)
+      - name: Install dependencies
+        run: npm ci
+        env:
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Build site
+        run: npm run build

--- a/static/CNAME
+++ b/static/CNAME
@@ -1,0 +1,1 @@
+legal.codat.io


### PR DESCRIPTION
## What

Deploy legal.codat.io to **GitHub Pages** via GitHub Actions, mirroring the [engineering-blog](https://github.com/codatio/engineering-blog) setup. Supersedes #73 (Azure Static Web Apps).

- `.github/workflows/deploy.yml` — push to `main` → `npm ci` → `docusaurus build` → `actions/deploy-pages`
- `.github/workflows/pr.yml` — build check on PRs
- `static/CNAME` — binds `legal.codat.io` (copied into `build/` by Docusaurus)

## Why GitHub Pages over SWA

- This repo is public, so Pages is free with custom-domain + HTTPS support
- No IaC stack, no SWA deployment token, no `staticwebapp.config.json` — the engineering-blog already proves this exact pattern in the org (custom codat.io subdomain, workflow-based Pages build)
- Kills [infrastructure-as-code#1445](https://github.com/codat-internal/infrastructure-as-code/pull/1445) for legal; [infrastructure-as-code#1443](https://github.com/codat-internal/infrastructure-as-code/pull/1443) (remove the Vercel module) still applies at cutover

**Tradeoff accepted:** no PR preview deployments — the PR check is build-only, same as the blog. Note fork PRs will fail the install step (the ADO registry in `.npmrc` needs `NPM_TOKEN`, which forks don't receive).

## Manual steps (before merge / at cutover)

1. Repo secret `NPM_TOKEN` (base64 ADO PAT — same value the Vercel project used)
2. Settings → Pages → Source: **GitHub Actions**
3. Cloudflare: switch the (unmanaged) `legal.codat.io` CNAME to `codatio.github.io` — DNS-only while the Pages cert issues, then re-enable proxy if wanted
4. Enforce HTTPS in the Pages settings once the cert is provisioned
5. Optional: approval gate via protection rules on the `github-pages` environment
6. After verified cutover: decommission the Vercel project (IaC #1443)

Jira: [EXP-1610](https://codatdocs.atlassian.net/browse/EXP-1610)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[EXP-1610]: https://codatdocs.atlassian.net/browse/EXP-1610?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ