### PR TITLE
EXP-2086: Add K8s/nginx container deployment (pattern-prover)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -28,10 +28,20 @@ jobs:
           node-version: 24
           cache: npm
 
-      - name: Install dependencies
-        run: npm ci
+      # The repo .npmrc is credential-less (the K8s image build authenticates
+      # via ADO npmAuthenticate); GH-hosted builds inject creds here instead.
+      - name: Authenticate to codat-npm feed
+        run: |
+          {
+            echo "//pkgs.dev.azure.com/codat/Codat/_packaging/codat-npm/npm/registry/:username=codat"
+            echo "//pkgs.dev.azure.com/codat/Codat/_packaging/codat-npm/npm/registry/:_password=${NPM_TOKEN}"
+            echo "//pkgs.dev.azure.com/codat/Codat/_packaging/codat-npm/npm/registry/:email=npm-requires-email@example.com"
+          } >> ~/.npmrc
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Install dependencies
+        run: npm ci
 
       - name: Build site
         run: npm run build

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -16,10 +16,18 @@ jobs:
 
       # The ADO registry in .npmrc requires auth even to install, so PR
       # builds need NPM_TOKEN too (fork PRs don't get secrets and will fail)
-      - name: Install dependencies
-        run: npm ci
+      - name: Authenticate to codat-npm feed
+        run: |
+          {
+            echo "//pkgs.dev.azure.com/codat/Codat/_packaging/codat-npm/npm/registry/:username=codat"
+            echo "//pkgs.dev.azure.com/codat/Codat/_packaging/codat-npm/npm/registry/:_password=${NPM_TOKEN}"
+            echo "//pkgs.dev.azure.com/codat/Codat/_packaging/codat-npm/npm/registry/:email=npm-requires-email@example.com"
+          } >> ~/.npmrc
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Install dependencies
+        run: npm ci
 
       - name: Build site
         run: npm run build

--- a/.npmrc
+++ b/.npmrc
@@ -1,5 +1,3 @@
 registry=https://pkgs.dev.azure.com/codat/Codat/_packaging/codat-npm/npm/registry/
+always-auth=true
 save-exact=true
-//pkgs.dev.azure.com/codat/Codat/_packaging/codat-npm/npm/registry/:username=codat
-//pkgs.dev.azure.com/codat/Codat/_packaging/codat-npm/npm/registry/:_password=${NPM_TOKEN}
-//pkgs.dev.azure.com/codat/Codat/_packaging/codat-npm/npm/registry/:email=npm-requires-email@example.com

--- a/.npmrc
+++ b/.npmrc
@@ -1,3 +1,2 @@
 registry=https://pkgs.dev.azure.com/codat/Codat/_packaging/codat-npm/npm/registry/
-always-auth=true
 save-exact=true

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,10 @@
+FROM nginx:1.29.6-alpine-slim AS final
+
+COPY --from=build /src/build /usr/share/nginx/html
+COPY --from=build /src/nginx.conf /etc/nginx/nginx.conf
+
+RUN rm /etc/nginx/conf.d/default.conf
+
+EXPOSE 80
+
+CMD ["nginx", "-g", "daemon off;"]

--- a/deployment/build.azure-pipelines.yaml
+++ b/deployment/build.azure-pipelines.yaml
@@ -1,0 +1,68 @@
+name: $(Date:yyyy.M.dd).$(Rev:r)
+
+trigger:
+  branches:
+    include:
+      - 'main'
+  paths:
+    exclude: []
+
+pr:
+  branches:
+    include:
+      - 'main'
+
+resources:
+  repositories:
+    - repository: 'templates'
+      type: 'git'
+      name: 'Codat/YAMLBuildTemplates'
+
+# Array values as Variables not supported by ADO
+parameters:
+  - name: ImagesToPublish
+    type: object
+    default:
+      - 'codat.legal.ui'
+
+  - name: DeploymentEnvironments
+    type: object
+    default:
+      - name: integration
+        shortCode: intg
+        pool:
+          name: codat-intg-managed-devops-pool-linux
+          demands:
+            - CustomCapabilities -equals $(Build.Repository.Name)
+        registryName: codatintgregistry
+
+      - name: production
+        shortCode: prod
+        pool: codat-prod-managed-devops-pool-linux
+        registryName: codatprodregistry
+
+stages:
+  - stage: 'build'
+    pool:
+      name: 'codat-intg-managed-devops-pool-linux'
+      demands:
+        - CustomCapabilities -equals $(Build.Repository.Name)
+    jobs:
+      - template: Helm/build.frontend.job.yaml@templates
+        parameters:
+          ImagesToPublish: ${{ parameters.ImagesToPublish }}
+          Version: '$(Build.BuildNumber)'
+          BuildFolder: deployment
+
+  - ${{ if not(in( variables['Build.Reason'], 'PullRequest' )) }}:
+    - ${{ each env in parameters.DeploymentEnvironments }}:
+      - ${{ if or(eq(variables['Build.SourceBranch'], 'refs/heads/main'), ne(env.name, 'production')) }}:
+        - stage: ${{ env.name }}
+          pool: ${{ env.pool }}
+          jobs:
+          - template: Helm/deploy.job.yaml@templates
+            parameters:
+              Environment: ${{ env.name }}
+              RegistryName: ${{ env.registryName }}
+              ImagesToPublish: ${{ parameters.ImagesToPublish }}
+              ArgoApplicationName: legal

--- a/deployment/charts/Chart.yaml
+++ b/deployment/charts/Chart.yaml
@@ -1,0 +1,8 @@
+apiVersion: 'v2'
+name: 'codat.legal'
+type: 'application'
+version: '0.0.1' # this is overwritten by the pipeline
+dependencies:
+  - name: 'codat-classic-app'
+    version: '>=2.6.1'
+    repository: 'oci://codatintgregistry.azurecr.io/base-charts'

--- a/deployment/charts/values-intg.yaml
+++ b/deployment/charts/values-intg.yaml
@@ -1,0 +1,19 @@
+codat-classic-app:
+  components:
+    - name: ui
+      image: codatintgregistry.azurecr.io/codat.legal.ui
+      routing:
+        - hosts: ["legal-integration.codat.io"]
+      containerPort: 80
+      statusPath: "/"
+      horizontalPodAutoscaling:
+        minReplicas: 1
+        maxReplicas: 2
+      podDisruptionBudget:
+        minAvailable: 0
+      resources:
+        requests:
+          memory: 20Mi
+          cpu: 10m
+        limits:
+          memory: 100Mi

--- a/deployment/charts/values-prod.yaml
+++ b/deployment/charts/values-prod.yaml
@@ -1,0 +1,19 @@
+codat-classic-app:
+  components:
+    - name: ui
+      image: codatprodregistry.azurecr.io/codat.legal.ui
+      routing:
+        - hosts: ["legal.codat.io"]
+      containerPort: 80
+      statusPath: "/"
+      horizontalPodAutoscaling:
+        minReplicas: 2
+        maxReplicas: 3
+      podDisruptionBudget:
+        minAvailable: 1
+      resources:
+        requests:
+          memory: 20Mi
+          cpu: 10m
+        limits:
+          memory: 100Mi

--- a/deployment/charts/values.yaml
+++ b/deployment/charts/values.yaml
@@ -1,0 +1,7 @@
+codat-classic-app:
+  appVersion: 0.0.0
+  metadata:
+    serviceName: legal
+    owningTeam: &team Pepper
+  env:
+    Codat_This_OwningTeam: *team

--- a/deployment/docker/build.dockerfile
+++ b/deployment/docker/build.dockerfile
@@ -9,6 +9,9 @@ WORKDIR /src
 
 COPY package.json .
 COPY package-lock.json .
+# Credential-less in the repo; the ADO pipeline's npm authenticate step injects
+# feed credentials into it before the bake (same mechanism as admin-ui /
+# link-amex). Local builds need your own authenticated .npmrc.
 COPY .npmrc .
 
 RUN npm ci

--- a/deployment/docker/build.dockerfile
+++ b/deployment/docker/build.dockerfile
@@ -1,0 +1,22 @@
+ARG DOCKER_REGISTRY
+
+FROM ${DOCKER_REGISTRY:-}base-images/node-build:24-bookworm-slim AS build
+
+# showLastUpdateAuthor/Time shell out to git; the slim base image doesn't ship it.
+RUN apt-get update && apt-get install -y --no-install-recommends git && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /src
+
+COPY package.json .
+COPY package-lock.json .
+COPY .npmrc .
+
+RUN npm ci
+
+# .git is deliberately NOT dockerignored: Docusaurus reads real last-updated
+# dates from git history (deploy.yml fetches full history for the same reason).
+COPY . .
+
+ENV CI=true
+
+RUN npm run build

--- a/deployment/docker/build.dockerfile.dockerignore
+++ b/deployment/docker/build.dockerfile.dockerignore
@@ -1,0 +1,11 @@
+# .git is intentionally included: Docusaurus showLastUpdateAuthor/Time read git history.
+.vscode
+.dockerignore
+.gitignore
+.env
+build
+node_modules
+Dockerfile
+README.md
+deployment
+.github

--- a/deployment/docker/docker-bake.hcl
+++ b/deployment/docker/docker-bake.hcl
@@ -1,0 +1,29 @@
+variable VERSION {
+    default = "dev"
+}
+
+variable DOCKER_REGISTRY {
+    default = "codatintgregistry.azurecr.io/"
+}
+
+group "default" {
+    targets = [
+        "build",
+        "app"
+    ]
+}
+
+target "build" {
+    context    = "./"
+    dockerfile = "deployment/docker/build.dockerfile"
+    args       = {
+        DOCKER_REGISTRY = "${DOCKER_REGISTRY}"
+    }
+    tags       = [ "codat.legal.build:${VERSION}" ]
+}
+
+target "app" {
+    contexts   = { "build" = "target:build" }
+    dockerfile = "Dockerfile"
+    tags       = [ "codat.legal.ui:${VERSION}" ]
+}

--- a/nginx.conf
+++ b/nginx.conf
@@ -1,0 +1,67 @@
+user  nginx;
+worker_processes  auto;
+
+error_log  /var/log/nginx/error.log notice;
+pid        /run/nginx.pid;
+
+events {
+    worker_connections  1024;
+}
+
+http {
+    include       /etc/nginx/mime.types;
+    default_type  application/octet-stream;
+
+    log_format  main  '$remote_addr - $remote_user [$time_local] "$request" '
+                      '$status $body_bytes_sent "$http_referer" '
+                      '"$http_user_agent" "$http_x_forwarded_for"';
+
+    access_log  /var/log/nginx/access.log  main;
+
+    sendfile        on;
+    tcp_nopush      on;
+    tcp_nodelay     on;
+    keepalive_timeout  65;
+
+    gzip on;
+    gzip_types text/plain text/css text/javascript application/javascript application/json application/x-javascript text/xml application/xml application/xml+rss;
+    gzip_min_length 256;
+    gzip_vary on;
+    gzip_proxied any;
+    gzip_comp_level 6;
+
+    include /etc/nginx/conf.d/*.conf;
+
+    server {
+        listen 80;
+        server_name localhost;
+        server_tokens off;
+        port_in_redirect off;
+
+        add_header X-XSS-Protection "1; mode=block";
+        add_header X-Permitted-Cross-Domain-Policies "none";
+        add_header Referrer-Policy "origin-when-cross-origin";
+        add_header X-Frame-Options "SAMEORIGIN";
+        add_header X-Content-Type-Options "nosniff";
+        add_header Strict-Transport-Security "max-age=63072000; includeSubDomains; preload";
+
+        root /usr/share/nginx/html;
+        index index.html;
+
+        # Static Docusaurus output: no SPA fallback — unknown paths get the
+        # generated 404 page with a real 404 status.
+        error_page 404 /404.html;
+
+        location / {
+            absolute_redirect off;
+            try_files $uri $uri/ =404;
+        }
+
+        # Disable .git directory
+        location ~ /\.git {
+            deny all;
+            access_log off;
+            log_not_found off;
+        }
+    }
+}

--- a/nginx.conf
+++ b/nginx.conf
@@ -38,12 +38,14 @@ http {
         server_tokens off;
         port_in_redirect off;
 
-        add_header X-XSS-Protection "1; mode=block";
-        add_header X-Permitted-Cross-Domain-Policies "none";
-        add_header Referrer-Policy "origin-when-cross-origin";
-        add_header X-Frame-Options "SAMEORIGIN";
-        add_header X-Content-Type-Options "nosniff";
-        add_header Strict-Transport-Security "max-age=63072000; includeSubDomains; preload";
+        # `always` so the headers are also sent on 404s (add_header only
+        # covers 2xx/3xx by default, and unknown paths here are real 404s).
+        add_header X-XSS-Protection "1; mode=block" always;
+        add_header X-Permitted-Cross-Domain-Policies "none" always;
+        add_header Referrer-Policy "origin-when-cross-origin" always;
+        add_header X-Frame-Options "SAMEORIGIN" always;
+        add_header X-Content-Type-Options "nosniff" always;
+        add_header Strict-Transport-Security "max-age=63072000; includeSubDomains; preload" always;
 
         root /usr/share/nginx/html;
         index index.html;


### PR DESCRIPTION
## Jira
[EXP-2086](https://codatdocs.atlassian.net/browse/EXP-2086) (pattern-prover for [EXP-2076](https://codatdocs.atlassian.net/browse/EXP-2076))

## What

Adds the standard containerised-frontend deployment shape so legal.codat.io can move from GitHub Pages onto a container on the Argo workload clusters. Mirrored from `codat-internal/admin-ui`:

- **`Dockerfile`** — `nginx:1.29.6-alpine-slim` final stage serving the Docusaurus `build/` output. No `run-app.sh`: there is no runtime env injection here, nginx starts directly.
- **`nginx.conf`** — admin-ui's config minus the SPA fallback: unknown paths return a real **404** via Docusaurus's generated `404.html` (`try_files $uri $uri/ =404` + `error_page 404 /404.html`).
- **`deployment/docker/`** — `build.dockerfile` on `base-images/node-build:24-bookworm-slim` (Node 24 matches the Pages workflow). Installs `git` and keeps `.git` in the build context so `showLastUpdateAuthor/Time` read real history (same reason `deploy.yml` uses `fetch-depth: 0`).
- **`deployment/charts/`** — `codat.legal` chart on `codat-classic-app` (>=2.6.1). Hosts: `legal-integration.codat.io` (intg) / `legal.codat.io` (prod). Small footprint (intg 1–2 replicas, prod 2–3, PDB 1) — traffic is minimal.
- **`deployment/build.azure-pipelines.yaml`** — `Helm/build.frontend.job.yaml` + `Helm/deploy.job.yaml`, `ArgoApplicationName: legal`.

**GitHub Pages keeps serving prod** — the Pages workflows still run on every merge. Cutover is a one-line DNS change in infrastructure-as-code once the intg hostname verifies; Pages decommission is a separate cleanup after a soak.

## npm feed (decided: keep codat-npm)

Staying on the ADO feed for supply-chain control. The committed `.npmrc` is now **credential-less** (registry + `always-auth`, matching admin-ui/link-amex) because the old `${NPM_TOKEN}` substitution lines break any npm run where the var is unset — including `npm ci` inside the image build. Credentials are injected at build time instead:

- **ADO pipeline**: the npm authenticate step writes creds into `.npmrc` before the bake — the same mechanism admin-ui and link-amex rely on.
- **Pages workflows**: a new "Authenticate to codat-npm feed" step writes the same three lines to `~/.npmrc` from `secrets.NPM_TOKEN`.

Fork-PR behaviour is unchanged (no secret → `npm ci` fails, as before).

## Still outside this PR

- ADO pipeline registration + `CustomCapabilities` for this repo on the managed pool, and confirming the `codat-tech` service connection reaches the codatio org — tracked on EXP-2086.

## Companion PRs

- codat-internal/argocd-state#41 — `Applications/legal.yaml` ApplicationSet
- codat-internal/infrastructure-as-code#1479 (staging DNS) / #1480 (held cutover)

> **Note on `owningTeam: Pepper`**: the team is now Client & Customer Experience, but the full name is not a valid k8s label value (the `codat-classic-app` chart writes `metadata.owningTeam` straight into the `owningTeam` label). Keeping `Pepper` for consistency with admin-ui / connectors / admin-site until the team picks a label-safe name and renames them in one sweep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[EXP-2086]: https://codatdocs.atlassian.net/browse/EXP-2086?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[EXP-2076]: https://codatdocs.atlassian.net/browse/EXP-2076?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ